### PR TITLE
Fixed a typo in arc-0030.

### DIFF
--- a/arc-0030/README.md
+++ b/arc-0030/README.md
@@ -107,7 +107,7 @@ function withdraw_token_two:
 
     finalize self.caller r1;
 
-finalize withdrawl_token_two:
+finalize withdraw_token_two:
     input r0 as address.public;
     input r1 as u64.public;
 


### PR DESCRIPTION
Fixed typo in "withdraw_token_two" function name, within finalize block.