### PR TITLE
feat(parser): discussion check

### DIFF
--- a/parser/index.js
+++ b/parser/index.js
@@ -10,8 +10,15 @@ const parseMD = require('parse-md').default;
  * topic: Meta
  * status: Living
  * created: 2020-02-07
- */
+*/
+// Add a new check for the discussion field in the ARC metadata
+
+if (!metadata.hasOwnProperty('discussion') || !metadata.discussion.trim()) {
+    console.error('\n', arcReadmeFile, 'is missing or has an empty \'discussion\' field.\n');
+    process.exit(1);
+}
 const requiredMetadata = ['arc', 'title', 'authors', 'discussion', 'topic', 'status', 'created'];
+
 
 const topics = ['Protocol', 'Network', 'Application', 'Meta'];
 


### PR DESCRIPTION
### Add a new check for the discussion field in the ARC metadata.

We have already  ` const requiredMetadata = ['arc', 'title', 'authors', 'discussion', 'topic', 'status', 'created'];`

**but we can do it with condition check like if-else**