### PR TITLE
docs: Rectify typographical inaccuracies

### DIFF
--- a/arc-0001/README.md
+++ b/arc-0001/README.md
@@ -10,7 +10,7 @@ created: 2020-02-07
 
 ## Abstract
 
-Aleo Request for Comments (ARCs) are protocol-level, network-level, and application-level standards for the Aleo ecosystem.
+Aleo Request for Comments (ARCs) is protocol-level, network-level, and application-level standards for the Aleo ecosystem.
 
 ## Specification
 

--- a/arc-0002/README.md
+++ b/arc-0002/README.md
@@ -281,7 +281,7 @@ Checks whether `first` and `second` are not equal, halting if they are equal.
 
 #### Description
 
-Returns the height of the block within the finalize scope.
+Returns the height of the block within the finalized scope.
 Currently, block height is the only supported property.
 
 #### Example Usage

--- a/arc-0003/README.md
+++ b/arc-0003/README.md
@@ -10,7 +10,7 @@ created: 9-29-2022
 
 ## Abstract
 
-The purpose of this ARC is to unify syntax between Leo and Aleo instructions to make it clear what tools developers have at their disposal. We propose several breaking changes to both Leo and Aleo instructions to achieve this goal.
+The purpose of this ARC is to unify syntax between Leo and Aleo's instructions to make it clear what tools developers have at their disposal. We propose several breaking changes to both Leo and Aleo's instructions to achieve this goal.
 
 | Leo V1           —> | Leo V2 & Aleo Instructions V2 | <—  Aleo Instructions V1 |
 |:-------------------:|:-----------------------------:|:------------------------:|
@@ -64,7 +64,7 @@ The following must be defined outside the program scope in a Leo file.
 * interface definitions.
 
 ### Interface Abstract Type
-Interfaces are being added to both Leo and Aleo instructions to relate types that have similar implementations.
+Interfaces are being added to both Leo and Aleo's instructions to relate types that have similar implementations.
 Interfaces are similar to classes in object-oriented programming languages.
 
 Interfaces can define

--- a/arc-0004/README.md
+++ b/arc-0004/README.md
@@ -32,7 +32,7 @@ boolean.
 
 The flagged operations are different from wrapped (e.g. `abs.w`) or
 lossy (e.g. `cast.lossy`) operations.  It is important that the flagged
-operation have the same semantics as the current halting instruction
+operation has the same semantics as the current halting instruction
 except for the halting behavior and extra return value, for ease of
 use by compilers.
 

--- a/arc-0030/README.md
+++ b/arc-0030/README.md
@@ -10,7 +10,7 @@ created: 9/2/2022
 
 ## Abstract
 
-Let's get NFTs & Tokens/DeFI working on Aleo. Currently, you can create an ERC-20/ERC-721-like program on Aleo but it is severly limited.
+Let's get NFTs & Tokens/DeFI working on Aleo. Currently, you can create an ERC-20/ERC-721-like program on Aleo but it is severely limited.
 The biggest limitation is that a program cannot own an NFT. This prevents these Aleo tokens from being used in: escrow, auctions, pools, etc.
 
 In order to enable this functionality, we need an opcode in the Aleo instruction set like: `self.parent`. This opcode would be similar to `self.caller` except it would result in the address of the program who called another program.


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.