### PR TITLE
Add IARC20 and IARC22 specifications

### DIFF
--- a/arc-0020/IARC20/.gitignore
+++ b/arc-0020/IARC20/.gitignore
@@ -1,0 +1,5 @@
+.env
+*.avm
+*.prover
+*.verifier
+outputs/

--- a/arc-0020/IARC20/program.json
+++ b/arc-0020/IARC20/program.json
@@ -1,0 +1,9 @@
+{
+  "program": "IARC20",
+  "version": "0.1.0",
+  "description": "",
+  "license": "MIT",
+  "leo": "4.0.2",
+  "dependencies": null,
+  "dev_dependencies": null
+}

--- a/arc-0020/IARC20/src/lib.leo
+++ b/arc-0020/IARC20/src/lib.leo
@@ -9,7 +9,7 @@ interface IARC20 {
     //=============================================================
     fn transfer_public(public recipient: address, public amount: u128) -> Final;
     fn transfer_private(private input: Token, private recipient: address, private amount: u128) -> (Token, Token);
-    fn transfer_private_to_public(private input: Token, public recipient: address, private amount: u128) -> (Token, Final);
+    fn transfer_private_to_public(private input: Token, public recipient: address, public amount: u128) -> (Token, Final);
     fn transfer_public_to_private(private recipient: address, public amount: u128) -> (Token, Final);
     fn transfer_public_as_signer(public recipient: address, public amount: u128) -> Final;
     fn transfer_from_public(public owner: address, public recipient: address, public amount: u128) -> Final;

--- a/arc-0020/IARC20/src/lib.leo
+++ b/arc-0020/IARC20/src/lib.leo
@@ -1,0 +1,44 @@
+interface IARC20 {
+    record Token {
+        owner: address,
+        amount: u128,
+        ..
+    }
+    //=============================================================
+    //               TRANSFER FUNCTIONS
+    //=============================================================
+    fn transfer_public(public recipient: address, public amount: u128) -> Final;
+    fn transfer_private(private input: Token, private recipient: address, private amount: u128) -> (Token, Token);
+    fn transfer_private_to_public(private input: Token, public recipient: address, private amount: u128) -> (Token, Final);
+    fn transfer_public_to_private(private recipient: address, public amount: u128) -> (Token, Final);
+    fn transfer_public_as_signer(public recipient: address, public amount: u128) -> Final;
+    fn transfer_from_public(public owner: address, public recipient: address, public amount: u128) -> Final;
+    fn transfer_from_public_to_private(
+        public owner: address,
+        private recipient: address,
+        public amount: u128,
+    ) -> (Token, Final);
+
+    //=============================================================
+    //               APPROVAL FUNCTIONS
+    //=============================================================
+    fn approve_public(public spender: address, public amount: u128) -> Final;
+    fn unapprove_public(public spender: address, public amount: u128) -> Final;
+
+    //=============================================================
+    //               JOIN/SPLIT FUNCTIONS
+    //=============================================================
+    fn join(private input_1: Token, private input_2: Token) -> Token;
+    fn split(private input: Token, private amount: u128) -> (Token, Token);
+
+    //=============================================================
+    //                VIEW FUNCTIONS
+    //=============================================================
+    view fn balance_of(account: address) -> u128;
+    view fn allowance(owner: address, spender: address) -> u128;
+    view fn supply() -> u128;
+    view fn max_supply() -> u128;
+    view fn decimals() -> u8;
+    view fn name() -> identifier;
+    view fn symbol() -> identifier;
+}

--- a/arc-0020/README.md
+++ b/arc-0020/README.md
@@ -12,15 +12,13 @@ created: 2026-03-18
 
 ARC-20 defines a fungible token standard for Aleo, supporting both public and private balances. Programs declare conformance to the `IARC20` interface, and any other program can call them at runtime via dynamic dispatch -- without compile-time knowledge of the specific token implementation.
 
-The standard defines a single **`IARC20`** interface covering public transfers, private transfers, approvals, joins, splits, and **`view fn`** accessors for name, symbol, decimals, balances, allowances, and supply. Reference deployments **[`wrapped_credits.aleo`](./wrapped_credits/)** and **[`wrapped_token_registry.aleo`](./wrapped_token_registry/)** both declare conformance to **`IARC20`** with identical interface signatures.
+The standard defines a single **`IARC20`** interface covering public transfers, private transfers, approvals, joins, splits, and **`view fn`** accessors for name, symbol, decimals, balances, allowances, and supply.
 
 For regulated tokens requiring freeze lists and compliance records, see [ARC-22](../arc-0022/).
 
 ## Motivation
 
 Without a standard interface, every DeFi program must import each token at compile time, making it impossible to build token-agnostic protocols. ARC-20 solves this through Leo's dynamic dispatch: a single AMM, lending protocol, or exchange can interact with any conforming token by name at runtime, with no recompilation or redeployment required.
-
-ARC-20 supersedes the previous ARC-20 draft (2023), which was written in Aleo instructions without interface support.
 
 ## Specification
 
@@ -37,23 +35,36 @@ interface IARC20 {
         amount: u128,
         ..
     }
-
+    //=============================================================
+    //               TRANSFER FUNCTIONS
+    //=============================================================
     fn transfer_public(public recipient: address, public amount: u128) -> Final;
+    fn transfer_private(private input: Token, private recipient: address, private amount: u128) -> (Token, Token);
+    fn transfer_private_to_public(private input: Token, public recipient: address, private amount: u128) -> (Token, Final);
+    fn transfer_public_to_private(private recipient: address, public amount: u128) -> (Token, Final);
     fn transfer_public_as_signer(public recipient: address, public amount: u128) -> Final;
-    fn approve_public(public spender: address, public amount: u128) -> Final;
-    fn unapprove_public(public spender: address, public amount: u128) -> Final;
     fn transfer_from_public(public owner: address, public recipient: address, public amount: u128) -> Final;
     fn transfer_from_public_to_private(
         public owner: address,
-        recipient: address,
+        private recipient: address,
         public amount: u128,
     ) -> (Token, Final);
-    fn transfer_private(input: Token, recipient: address, amount: u128) -> (Token, Token);
-    fn transfer_private_to_public(input: Token, public recipient: address, public amount: u128) -> (Token, Final);
-    fn transfer_public_to_private(recipient: address, public amount: u128) -> (Token, Final);
-    fn join(input_1: Token, input_2: Token) -> Token;
-    fn split(input: Token, amount: u128) -> (Token, Token);
 
+    //=============================================================
+    //               APPROVAL FUNCTIONS
+    //=============================================================
+    fn approve_public(public spender: address, public amount: u128) -> Final;
+    fn unapprove_public(public spender: address, public amount: u128) -> Final;
+
+    //=============================================================
+    //               JOIN/SPLIT FUNCTIONS
+    //=============================================================
+    fn join(private input_1: Token, private input_2: Token) -> Token;
+    fn split(private input: Token, private amount: u128) -> (Token, Token);
+
+    //=============================================================
+    //                VIEW FUNCTIONS
+    //=============================================================
     view fn balance_of(account: address) -> u128;
     view fn allowance(owner: address, spender: address) -> u128;
     view fn supply() -> u128;
@@ -64,14 +75,6 @@ interface IARC20 {
 }
 ```
 
-Notes on signatures:
-
-- `transfer_public_as_signer` is the signer-scoped variant of `transfer_public`, mirroring the existing primitives in `credits.aleo` / `token_registry.aleo`.
-- `transfer_from_public_to_private` includes an explicit `recipient` (declared **`private`**, so the receiving address is not revealed on-chain) so the spender can route the resulting `Token` to a third party.
-- `transfer_private_to_public` returns only **`(Token, Final)`** -- the change record plus a finalization future. The spender's original `Token` is consumed; the change record returned to **`input.owner`** is the spender's fresh receipt.
-- `join` / `split` mirror the helpers offered by other Aleo tokens.
-- **`view fn`** reads (**`balance_of`**, **`allowance`**, **`supply`**, **`max_supply`**, **`decimals`**, **`name`**, **`symbol`**) are part of the interface contract and enable off-consensus reads (SDK / explorers) through Leo 4's view function machinery.
-
 ### Record Types
 
 **Token** -- Represents a private token balance. Implementations may add additional fields beyond `owner` and `amount`:
@@ -80,42 +83,17 @@ Notes on signatures:
 record Token {
     owner: address,
     amount: u128,
+    ..
 }
 ```
 
 The interface explicitly allows extra fields with `..`, but a conforming implementation must include at least `owner: address` and `amount: u128`.
 
-### Programs
 
-| Program | Description |
-|---------|-------------|
-| [`token_registry.aleo`](./token_registry/) | Multi-token registry supporting token registration, role-based access, and authorized balances. Manages public and private balances for arbitrary token IDs. |
-| [`wrapped_credits.aleo`](./wrapped_credits/) | **`IARC20`** wrapper around `credits.aleo`. Deposits Aleo credits and issues 1:1 wrapped tokens. |
-| [`wrapped_token_registry.aleo`](./wrapped_token_registry/) | **`IARC20`** wrapper fixing one `token_registry.aleo` token ID (`WRAPPED_TOKEN_ID`); same interface surface as **`wrapped_credits`** aside from the deposit/withdraw helpers. |
-| [`dummy_exchange.aleo`](./dummy_exchange/) | Dynamic dispatch example -- demonstrates `transfer_from_public` and `swap` to interact with any ARC20 token by program identifier at runtime. |
-
-### Reference wrappers
-
-[`wrapped_credits/src/main.leo`](./wrapped_credits/src/main.leo) and [`wrapped_token_registry/src/main.leo`](./wrapped_token_registry/src/main.leo) declare an **identical** **`IARC20`** interface block and implement every required transition and **`view fn`**. Implementation-level conventions shared by both:
-
-| Topic | **`wrapped_credits.aleo`** / **`wrapped_token_registry.aleo`** |
-|--------|--------------------------------------------------------------|
-| Public balance storage | **`mapping balances: address => u128`** |
-| Allowance storage | **`mapping allowances: TokenAllowance => u128`**, where **`TokenAllowance { account, spender }`** is used as the map key directly |
-| Metadata & supply | **`storage token_info: TokenInfo`** singleton (`name`, `symbol`, `decimals`, `supply`, `max_supply`) |
-| Supply bookkeeping | Shared top-level **`final fn add_supply` / `sub_supply`** invoked from deposit / withdraw paths |
-| View fn metadata | **`view fn name() -> identifier`** and **`view fn symbol() -> identifier`** return Leo identifier literals (e.g. `'wCredits'`, `'wCRD'`) |
-
-Bridging to the underlying program uses wrapper-specific helpers that are **not** part of **`IARC20`**: **`wrapped_credits`** -- **`deposit_credits_public_signer`**, **`deposit_credits_private`**, **`withdraw_credits_public`**, **`withdraw_credits_public_signer`**, **`withdraw_credits_private`**; **`wrapped_token_registry`** -- **`deposit_token_public`**, **`withdraw_token_*`**.
 
 ### Dynamic Dispatch
 
 ARC-20 tokens are called via dynamic dispatch, which resolves the target program at runtime. This allows a single program (e.g. an AMM or lending protocol) to interact with *any* ARC20-implementing token without importing it at compile time.
-
-Leo provides two ways to make dynamic calls:
-
-1. **Interface-enforced syntax** ([leo#29201](https://github.com/ProvableHQ/leo/pull/29201)) -- the compiler validates function names, argument types, and return types against the interface definition at compile time. This is the recommended approach.
-2. **`_dynamic_call` intrinsic** -- a low-level escape hatch that bypasses interface checking. The caller manually encodes function selectors as `field` constants and is responsible for passing correct arguments. Useful when working below the interface abstraction or with programs that don't declare interface conformance.
 
 #### Interface-Enforced Syntax
 
@@ -185,19 +163,11 @@ fn deposit_private(
 }
 ```
 
-See [`dummy_exchange.aleo`](./dummy_exchange/) for a working dynamic dispatch example using the low-level `_dynamic_call` intrinsic. A full AMM reference implementation is forthcoming.
-
 #### Example: Implementing an ARC20 Token
 
 A program declares interface conformance with `: InterfaceName`:
 
 ```leo
-interface IARC20 {
-    record Token { owner: address, amount: u128, .. }
-    fn transfer_public(public recipient: address, public amount: u128) -> Final;
-    // ... other required functions and view fn accessors
-}
-
 program my_token.aleo: IARC20 {
     record Token {
         owner: address,
@@ -207,119 +177,25 @@ program my_token.aleo: IARC20 {
     fn transfer_public(public recipient: address, public amount: u128) -> Final {
         // ...
     }
+
+    // ... other required functions and view fn accessors
 }
 ```
 
-See [`wrapped_credits.aleo`](./wrapped_credits/src/main.leo) and [`wrapped_token_registry.aleo`](./wrapped_token_registry/src/main.leo) for complete **`IARC20`** implementations.
 
-## Test Cases
-
-Tests use Jest with a local devnode and Leo CLI execution.
-
-**IARC20 shared interface tests** (`arc20-wrapper-tests.js`), run for both `wrapped_credits` and `wrapped_token_registry`:
-
-- All transfer variants: `transfer_public`, `transfer_public_as_signer`, `transfer_private`, `transfer_private_to_public` (returns change **`Token`** + **`Final`**), `transfer_public_to_private`
-- Public↔private round-trips via **`transfer_public_to_private` / `transfer_private_to_public`**
-- Approve/unapprove + `transfer_from_public` / `transfer_from_public_to_private` allowance management (the latter includes an explicit private `recipient`)
-- `join` / `split`
-- **`view fn`** reads: `balance_of`, `allowance`, `supply`, `max_supply`, `decimals`, `name`, `symbol`
-- Negative tests: insufficient balance, exceeded allowance
-
-## Rationale
+### Design Notes
 
 - **Additive approvals**: `approve_public` increases the existing allowance rather than replacing it. This avoids race conditions -- two `approve_public` calls in the same block will both succeed and add to the allowance, rather than one silently overwriting the other.
+
 - **u128 amounts**: Future-proofs the standard for high-supply tokens and avoids truncation issues. `u64` would limit maximum supply to ~18.4 quintillion base units, which is insufficient for some token designs.
+
 - **`recipient` naming**: The receiving address is consistently named `recipient` across transfer variants.
+
 - **`transfer_private_to_public` returns `(Token, Final)`**: the spender's private `Token` is consumed during the transfer; the change `Token` (owned by the original spender) is the spender's fresh receipt, avoiding the need to scan `sk_tag` for the spent record.
+
 - **`view fn` on the interface**: `balance_of`, `allowance`, `supply`, `max_supply`, `decimals`, `name`, `symbol` are part of the interface contract so off-consensus consumers (SDK, explorers, indexers) have a uniform read API without depending on implementation-specific mapping/storage layouts.
 
-## Reference Implementations
-
-- [`wrapped_credits/`](./wrapped_credits/) -- **`IARC20`** wrapping `credits.aleo`
-- [`wrapped_token_registry/`](./wrapped_token_registry/) -- **`IARC20`** wrapping a fixed `token_registry.aleo` token ID
-- [`token_registry/`](./token_registry/) -- Multi-token registry
-- [`dummy_exchange/`](./dummy_exchange/) -- Dynamic dispatch interoperability example
-
-## Dependencies
-
-- **Leo compiler** with interface/dynamic dispatch support (Leo 4.0+)
-- **@provablehq/sdk** (for SDK-based testing)
-
-## Backwards Compatibility
-
-This ARC supersedes the previous ARC-20 draft (2023). The prior spec was written in Aleo instructions without interface support. Programs implementing the old spec are not compatible with the new interface-based standard.
-
-### Why Wrappers Are Needed
-
-Existing programs cannot directly implement the **`IARC20`** interface for three reasons:
-
-1. **Record name mismatch**: `credits.aleo` defines `record credits`, not `record Token`. The **`IARC20`** interface requires `record Token`. *(Not currently enforced at protocol level, but expected by consuming programs.)*
-2. **Record entry name mismatch**: `credits.aleo` uses `microcredits` as the balance field, not `amount`. *(Enforced at protocol level; may become relaxable in future.)*
-3. **Record entry type mismatch**: `credits.aleo` uses `u64` for amounts, while **`IARC20`** uses `u128`. *(Permanently enforced -- types affect circuit size and cannot be aliased.)*
-
-### Incompatible Programs
-
-| Program | Record | Transfer Signature | Why Incompatible |
-|---------|--------|--------------------|------------------|
-| `credits.aleo` | `record credits { owner: address, microcredits: u64 }` | `transfer_public(address, u64)` | Wrong record name/fields, u64 vs u128 |
-| `token_registry.aleo` | `record Token { owner, amount, token_id, ... }` | `transfer_public(field, address, u128)` | Extra `token_id` parameter |
-
-Any program whose public transfer signature differs from `transfer_public(address, u128)` requires a stateful wrapper.
-
-### Stateless vs Stateful Wrappers
-
-A **stateless** wrapper (pure forwarding) cannot work because:
-
-- Interface conformance cannot rename records or remap field names
-- `self.caller` in the underlying program would be the wrapper, not the original caller -- breaking escrow patterns where a third-party program needs to hold tokens
-
-A **stateful** wrapper maintains its own `balances` mapping and exposes the standard **`IARC20`** interface. Deposit/withdraw functions bridge between the wrapper's internal balances and the underlying program. See [`wrapped_credits.aleo`](./wrapped_credits/src/main.leo) and [`wrapped_token_registry.aleo`](./wrapped_token_registry/src/main.leo) for reference implementations.
-
-### Public/Private Considerations
-
-- Implementations such as **`wrapped_credits`** and **`wrapped_token_registry`** convert between public and private balances through **`transfer_public_to_private`** / **`transfer_private_to_public`** entirely within wrapper-local state. No interaction with the underlying token is required for these balance moves.
-- `transfer_private_to_public` has a UX limitation: the recipient receives tokens in their public balance but cannot learn the private sender's identity (by design). The sender can still locate the spent record off-chain via their `sk_tag`; the returned change `Token` (owned by the spender) also serves as a fresh receipt.
-
-## Migration Guide: Wrapping Token Registry Tokens
-
-Teams that have already deployed tokens to `token_registry.aleo` can make them ARC20-compatible by deploying a stateful wrapper.
-
-### Why Wrapping Is Needed
-
-`token_registry.aleo` functions take an extra `token_id: field` parameter:
-
-```
-token_registry.aleo::transfer_public(token_id, recipient, amount)  // 3 params
-IARC20::transfer_public(recipient, amount)                         // 2 params
-```
-
-This signature mismatch means `token_registry.aleo` cannot directly implement the **`IARC20`** interface.
-
-### How to Create a Wrapper
-
-1. Deploy a new program declaring conformance to **`IARC20`** (as used by [`wrapped_token_registry`](./wrapped_token_registry/))
-2. Set a `WRAPPED_TOKEN_ID` constant for your token's ID in the registry
-3. Maintain local `balances: address => u128` and `allowances: TokenAllowance => u128` mappings, plus a `storage token_info: TokenInfo;` singleton
-4. Implement deposit/withdraw to bridge between the wrapper and the registry:
-    - `deposit_token_public(amount)`: calls `token_registry.aleo::transfer_public_as_signer(TOKEN_ID, self.address, amount)`, increments local balance
-    - `withdraw_token_public(amount)`: decrements local balance, calls `token_registry.aleo::transfer_public(TOKEN_ID, withdrawer, amount)`
-5. Implement transfers, approvals, **`view fn`** reads, joins/splits, deposit/withdraw helpers, and **`transfer_public_to_private` / `transfer_private_to_public`** for public↔private moves.
-
-### Deposit/Withdraw Flow
-
-```
-                    deposit_token_public(100)                    transfer_public_as_signer
-  User  ──────────────────────────────────►  wrapper.aleo       ─────────────────────────────►  token_registry
-                                             balances[user]+=100    (TOKEN_ID, self.addr, 100)   balances[wrapper]
-
-                    withdraw_token_public(100)                   transfer_public
-  User  ──────────────────────────────────►  wrapper.aleo       ─────────────────────────────►  token_registry
-                                             balances[user]-=100    (TOKEN_ID, user, 100)        balances[user]
-```
-
-### Reference
-
-See [`wrapped_token_registry/`](./wrapped_token_registry/) for a complete implementation wrapping token ID `99999field`.
+- **`transfer_from_public_to_private` includes an explicit `recipient`**: Declared **`private`**, so the receiving address is not revealed on-chain, which allows the spender to route the resulting `Token` to a third party.
 
 ## Comparison to ERC-20
 
@@ -327,7 +203,7 @@ For developers familiar with Ethereum's ERC-20 standard:
 
 | ERC-20 | ARC-20 (**`IARC20`**) | Notes |
 |--------|----------------------|-------|
-| `balanceOf(address)` | `view fn balance_of(account) -> u128` | Off-consensus read via Leo 4 **`view fn`**; underlying `balances` mapping also queryable directly |
+| `balanceOf(address)` | `view fn balance_of(account) -> u128` | Off-consensus read via Leo v4.0 **`view fn`**; underlying `balances` mapping also queryable directly |
 | `totalSupply()` | `view fn supply() -> u128` | Reads `storage token_info.supply`; `view fn max_supply() -> u128` exposes the configured cap |
 | `decimals()` | `view fn decimals() -> u8` | Reads `storage token_info.decimals` |
 | `name()` / `symbol()` | `view fn name() -> identifier` / `view fn symbol() -> identifier` | Reference wrappers return Leo identifier literals (`'wCredits'`, `'wCRD'`, `'wTokReg'`, `'wTR'`) |
@@ -339,28 +215,39 @@ For developers familiar with Ethereum's ERC-20 standard:
 | -- | `join(a, b)` / `split(a, n)` | Manage record granularity |
 | Contract address = token | Program name = token | Each ARC-20 token is its own deployed program |
 
-## Security Considerations
+### Security Considerations
 
 **Approval model**: ARC-20 uses additive approvals -- `approve_public` increases the allowance, and `unapprove_public` decreases it. This differs from ERC-20's replace semantics. To change an allowance from 100 to 50, call `unapprove_public(50)` rather than setting a new value. Calling `approve_public` without first reducing the existing allowance will add to it.
 
 **Arithmetic overflow/underflow**: Leo's `u128` arithmetic aborts the transaction on underflow/overflow (enforced by the Aleo VM). Implementations therefore omit redundant explicit `assert(... >= amount)` checks in `transfer_from_public`, `transfer_from_public_to_private`, and `unapprove_public` -- the VM aborts naturally on underflow.
 
-**Self.caller vs self.signer**: Wrapper programs must carefully distinguish between `self.caller` (the immediate caller, which may be another program) and `self.signer` (the transaction originator). Deposit functions use `self.signer` to pull from the user's underlying balance, while transfer functions use `self.caller` for composability with DeFi programs. The interface exposes both `transfer_public` (caller-scoped) and `transfer_public_as_signer` (signer-scoped) so consumers can pick the appropriate semantics.
+**`self.caller` vs `self.signer`**: Wrapper programs must carefully distinguish between `self.caller` (the immediate caller, which may be another program) and `self.signer` (the transaction originator). Deposit functions use `self.signer` to pull from the user's underlying balance, while transfer functions use `self.caller` for composability with DeFi programs. The interface exposes both `transfer_public` (caller-scoped) and `transfer_public_as_signer` (signer-scoped) so consumers can pick the appropriate semantics.
 
-## Testing
 
-Prerequisites:
 
-- Leo compiler with interface support (Leo 4.0+)
-- Node.js 18+
+## Special Exception: `credits.aleo`
 
-```bash
-cd arc-0020/tests
-npm install
-npm test                    # Run all tests (requires local devnode)
-```
+The program for the native Aleo Credits asset cannot directly implement the **`IARC20`** interface for three reasons:
 
-Tests start a local devnode, deploy programs with their dependencies, and execute transactions via `leo execute`.
+1. **Record name mismatch**: `credits.aleo` defines `record credits`, not `record Token`. The **`IARC20`** interface requires `record Token`. *(Not currently enforced at protocol level, but expected by consuming programs.)*
+2. **Record entry name mismatch**: `credits.aleo` uses `microcredits` as the balance field, not `amount`. *(Enforced at protocol level; may become relaxable in future.)*
+3. **Record entry type mismatch**: `credits.aleo` uses `u64` for amounts, while **`IARC20`** uses `u128`. *(Permanently enforced -- types affect circuit size and cannot be aliased.)*
+
+
+### Stateless vs Stateful Wrappers
+
+A **stateless** wrapper (pure forwarding) cannot work because:
+
+- Interface conformance cannot rename records or remap field names
+- `self.caller` in the underlying program would be the wrapper, not the original caller -- breaking escrow patterns where a third-party program needs to hold tokens
+
+A **stateful** wrapper maintains its own `balances` mapping and exposes the standard **`IARC20`** interface. Deposit/withdraw functions bridge between the wrapper's internal balances and the underlying program. 
+
+### Public/Private Considerations
+
+- Implementations convert between public and private balances through **`transfer_public_to_private`** / **`transfer_private_to_public`** entirely within wrapper-local state. No interaction with the underlying token is required for these balance moves.
+- `transfer_private_to_public` has a UX limitation: the recipient receives tokens in their public balance but cannot learn the private sender's identity (by design). The sender can still locate the spent record off-chain via their `sk_tag`; the returned change `Token` (owned by the spender) also serves as a fresh receipt.
+
 
 ## Copyright
 

--- a/arc-0022/.gitignore
+++ b/arc-0022/.gitignore
@@ -1,0 +1,2 @@
+./.gitignore
+./compliant_token_template/

--- a/arc-0022/IARC22/.gitignore
+++ b/arc-0022/IARC22/.gitignore
@@ -1,0 +1,5 @@
+.env
+*.avm
+*.prover
+*.verifier
+outputs/

--- a/arc-0022/IARC22/program.json
+++ b/arc-0022/IARC22/program.json
@@ -1,0 +1,9 @@
+{
+  "program": "IARC22",
+  "version": "0.1.0",
+  "description": "",
+  "license": "MIT",
+  "leo": "4.0.2",
+  "dependencies": null,
+  "dev_dependencies": null
+}

--- a/arc-0022/IARC22/src/lib.leo
+++ b/arc-0022/IARC22/src/lib.leo
@@ -1,0 +1,205 @@
+// The 'IARC22' library.
+const MAX_TREE_DEPTH: u32 = 15u32;
+
+// ZERO_ADDRESS as field == 0field
+const ZERO_ADDRESS: address = aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc;
+
+// EMPTY_ROOT == hash of H(ZERO_ADDRESS, ZERO_ADDRESS)
+const EMPTY_ROOT: field = 3642222252059314292809609689035560016959342421640560347114299934615987159853field;
+
+struct MerkleProof {
+    siblings: [field; MAX_TREE_DEPTH + 1],
+    leaf_index: u32,
+}
+
+//=============================================================
+//               MERKLE TREE HELPER FUNCTIONS
+//=============================================================
+// Calculates the hash of two sibling nodes in a Merkle tree.
+// The order of the siblings depends on the index bit (0 = left, 1 = right).
+// Uses Poseidon hash to compute the result.
+fn calculate_hash_for_nodes(sibling1: field, sibling2: field, indexbit: u32) -> field {
+    let poseidon_params: [field; 3] = indexbit == 0u32 ? [0field, sibling1, sibling2] : [
+        0field,
+        sibling2,
+        sibling1,
+    ];
+    return Poseidon4::hash_to_field(poseidon_params);
+}
+
+fn calculate_hash_for_leaves(sibling1: field, sibling2: field, indexbit: u32) -> field {
+    let poseidon_params: [field; 3] = indexbit == 0u32 ? [1field, sibling1, sibling2] : [
+        1field,
+        sibling2,
+        sibling1,
+    ];
+    return Poseidon4::hash_to_field(poseidon_params);
+}
+
+// Calculates the Merkle root and the depth of a Merkle proof path.
+// Iteratively hashes the sibling path based on the leaf index to reconstruct the root.
+// Stops when a zero field is encountered in the siblings array, indicating the end of the valid path.
+// Returns the calculated root and the actual depth reached.
+fn calculate_root_depth_siblings(merkle_proof: MerkleProof) -> (field, u32) {
+    let root: field = calculate_hash_for_leaves(
+        merkle_proof.siblings[0u8],
+        merkle_proof.siblings[1u8],
+        merkle_proof.leaf_index % 2u32,
+    );
+    for i: u32 in 2u32..MAX_TREE_DEPTH + 1u32 {
+        if (merkle_proof.siblings[i] == 0field) {
+            return (root, i - 1u32);
+        }
+        root = calculate_hash_for_nodes(
+            root,
+            merkle_proof.siblings[i],
+            (merkle_proof.leaf_index / (2u32 ** (i - 1u32))) % 2u32,
+        );
+    }
+    return (root, MAX_TREE_DEPTH);
+}
+
+// Verifies that the given address is included in a Merkle tree.
+// Asserts that the address matches the first sibling (leaf node).
+// Computes the Merkle root and returns it for comparison against a known root.
+fn verify_inclusion(addr: address, merkle_proof: MerkleProof) -> field {
+    assert_eq(addr as field, merkle_proof.siblings[0u32]);
+    let (root, depth): (field, u32) = calculate_root_depth_siblings(merkle_proof);
+    return root;
+}
+
+// Verifies non-inclusion of an address in a Merkle tree sorted in ascending order by address (as field).
+// Accepts two Merkle proofs representing the neighboring leaves around the missing address.
+// Returns the common Merkle root if the address is proven to be outside the tree.
+// If the tree is not sorted correctly, this function may return incorrect results.
+fn verify_non_inclusion(addr: address, merkle_proofs: [MerkleProof; 2]) -> field {
+    let (root1, depth1): (field, u32) = calculate_root_depth_siblings(merkle_proofs[0u32]);
+    let (root2, depth2): (field, u32) = calculate_root_depth_siblings(merkle_proofs[1u32]);
+
+    // Ensure the roots from the merkle proofs are the same
+    assert_eq(root1, root2);
+    // Ensure the depth of the merkle proofs is the same
+    assert_eq(depth1, depth2);
+
+    let addr_field: field = addr as field;
+    if (merkle_proofs[0u32].leaf_index == merkle_proofs[1u32].leaf_index) {
+        // Ensure that if the address is the most left leaf, it is less than the first sibling
+        if (merkle_proofs[0u32].leaf_index == 0u32) {
+            assert(addr_field < merkle_proofs[0u32].siblings[0u32]);
+        } else {
+            // Ensure that if the address is the most right leaf
+            let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
+            assert_eq(merkle_proofs[0u32].leaf_index, last_index_leaf);
+            // Ensure that the address is bigger than the first sibling
+            assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
+        }
+    } else {
+        // Ensure the address is in between the provided leaves
+        assert(addr_field > merkle_proofs[0u32].siblings[0u32]);
+        assert(addr_field < merkle_proofs[1u32].siblings[0u32]);
+
+        // Ensure that the leaf indexes are not greater than the last possible leaf index
+        let last_index_leaf: u32 = 2u32 ** depth1 - 1u32;
+        assert(merkle_proofs[1u32].leaf_index <= last_index_leaf);
+
+        // Ensure the leaves are adjacent
+        assert_eq(merkle_proofs[0u32].leaf_index + 1u32, merkle_proofs[1u32].leaf_index);
+    }
+    return root1;
+}
+
+interface IARC22Freezelist {
+    // Initializes the freeze list and the admin. Sets the block height window, the initial empty Merkle root,
+    fn initialize(public admin: address, public blocks: u32) -> Final;
+
+    // Freezes or unfreezes an account based on the action flag (true = freeze, false = unfreeze)
+    fn update_freeze_list(
+        public account: address,
+        public is_frozen: bool,
+        public index: u32,
+        public existing_root: field,
+        public new_root: field,
+    ) -> Final;
+
+    // Verifies that an account is not currently frozen.
+    fn verify_non_inclusion_pub(public account: address) -> Final;
+
+    // Verifies that an account is not included in the freeze list Merkle tree.
+    fn verify_non_inclusion_priv(account: address, merkle_proof: [MerkleProof; 2u32]) -> Final;
+
+    //=============================================================
+    //                VIEW FUNCTIONS
+    //=============================================================
+    view fn is_frozen_address(account: address) -> bool;
+    view fn is_frozen_index(index: u32) -> bool;
+    view fn current_freeze_list_root() -> field;
+    view fn previous_freeze_list_root() -> field;
+    view fn root_updated_height() -> u32;
+    view fn block_height_window() -> u32;
+}
+
+interface IARC22 {
+    record Token {
+        owner: address,
+        amount: u128,
+        ..
+    }
+
+    record ComplianceRecord {
+        owner: address,     // INVESTIGATOR_ADDRESS
+        amount: u128,
+        sender: address,    // ZERO_ADDRESS for mint paths
+        recipient: address, // ZERO_ADDRESS for burn paths
+        .. 
+    }
+
+    //=============================================================
+    //               APPROVAL FUNCTIONS
+    //=============================================================
+    fn approve_public(public spender: address, public amount: u128) -> Final;
+    fn unapprove_public(public spender: address, public amount: u128) -> Final;
+
+    //=============================================================
+    //               TRANSFER FUNCTIONS
+    //=============================================================
+    fn transfer_public(public recipient: address, public amount: u128) -> Final;
+    fn transfer_private(
+        private recipient: address,
+        private amount: u128,
+        private input_record: Token,
+        private sender_merkle_proofs: [MerkleProof; 2u32],
+    ) -> (ComplianceRecord, Token, Token, Final);
+    fn transfer_private_to_public(
+        public recipient: address,
+        public amount: u128,
+        private input_record: Token,
+        private sender_merkle_proofs: [MerkleProof; 2u32],
+    ) -> (ComplianceRecord, Token, Final);
+    fn transfer_public_to_private(recipient: address, public amount: u128) -> (
+        ComplianceRecord, Token, Final,
+    );
+    fn transfer_from_public(public owner: address, public recipient: address, public amount: u128) -> Final;
+    fn transfer_from_public_to_private(
+        public owner: address,
+        private recipient: address,
+        public amount: u128,
+    ) -> (ComplianceRecord, Token, Final);
+    fn transfer_public_as_signer(public recipient: address, public amount: u128) -> Final;
+
+    //=============================================================
+    //               JOIN/SPLIT FUNCTIONS
+    //=============================================================
+    fn join(input_1: Token, input_2: Token) -> Token;
+    fn split(input: Token, amount: u128) -> (Token, Token);
+
+    //=============================================================
+    //                VIEW FUNCTIONS
+    //=============================================================
+    view fn balance_of(account: address) -> u128;
+    view fn allowance(owner: address, spender: address) -> u128;
+    view fn supply() -> u128;
+    view fn max_supply() -> u128;
+    view fn decimals() -> u8;
+    view fn name() -> identifier;
+    view fn symbol() -> identifier;
+}

--- a/arc-0022/README.md
+++ b/arc-0022/README.md
@@ -10,13 +10,11 @@ created: 2026-03-18
 
 ## Abstract
 
-ARC-22 defines a compliant fungible token interface for Aleo. It extends [ARC-20](../arc-0020/) with freeze-list enforcement and compliance records for regulated token issuers (stablecoins, security tokens). ARC-22 preserves Aleo's privacy guarantees while enabling regulatory oversight through Merkle non-inclusion proofs and investigator-visible compliance records.
-
-The reference program [`compliant_token_template.aleo`](./compliant_token_template/) declares the Leo interface **`IARC22`** with core transfers, **`view fn`** reads, and compliance-bearing transitions. The signatures below match [`compliant_token_template/src/main.leo`](./compliant_token_template/src/main.leo) exactly.
+ARC-22 defines a compliant fungible token interface for Aleo. It modifies [ARC-20](../arc-0020/) with freeze-list enforcement and compliance records for regulated token issuers (stablecoins, security tokens). ARC-22 preserves Aleo's privacy guarantees while enabling regulatory oversight through Merkle non-inclusion proofs and investigator-visible compliance records.
 
 ## Motivation
 
-ARC-20 provides a minimal token standard but lacks regulatory compliance features required by many real-world token deployments. Regulated tokens need:
+ARC-20 provides a minimal token standard but lacks regulatory compliance features required by many real-world token deployments. Regulated tokens compliance mechanisms such as:
 
 1. **Freeze lists** to block sanctioned or compromised addresses from transacting
 2. **Audit trails** for private transfers, enabling authorized investigators to review token movements without exposing sender identity to the public
@@ -25,9 +23,16 @@ ARC-22 adds these capabilities while preserving Aleo's privacy guarantees throug
 
 ## Specification
 
+The ARC-22 standard provides a library ([`IARC22`](./IARC22)), which is composed of:
+
+- Two interfaces, **`IARC22`** and **`IARC22Freezelist`**, defining the token and freeze-list contracts
+- A **`MerkleProof`** struct used by the non-inclusion proof flow
+- A small set of **constants** (`MAX_TREE_DEPTH`, `ZERO_ADDRESS`, `EMPTY_ROOT`)
+- **Merkle helper functions** that implementations call to verify proofs
+
 ### `IARC22`
 
-The compliant token surface adds freeze-list enforcement (via Merkle non-inclusion proofs on private sends) and investigator-visible **`ComplianceRecord`** outputs on every transition that materially changes a balance. Mappings and storage variables are intentionally **not** part of the interface body—only function signatures and the records (**`Token`**, **`ComplianceRecord`**) form the contract.
+The compliant token surface adds freeze-list enforcement (via Merkle non-inclusion proofs on private sends) and investigator-visible **`ComplianceRecord`** outputs on every transition that materially changes a balance. Mappings and storage variables are intentionally **not** part of the interface; only function signatures and the records (**`Token`**, **`ComplianceRecord`**) form the contract.
 
 ```leo
 interface IARC22 {
@@ -38,46 +43,55 @@ interface IARC22 {
     }
 
     record ComplianceRecord {
-        owner: address,
+        owner: address,     // INVESTIGATOR_ADDRESS
         amount: u128,
-        sender: address,
-        recipient: address,
+        sender: address,    // ZERO_ADDRESS for mint paths
+        recipient: address, // ZERO_ADDRESS for burn paths
         ..
     }
 
-    fn transfer_public(public recipient: address, public amount: u128) -> Final;
-    fn transfer_public_as_signer(public recipient: address, public amount: u128) -> Final;
-
+    //=============================================================
+    //               APPROVAL FUNCTIONS
+    //=============================================================
     fn approve_public(public spender: address, public amount: u128) -> Final;
     fn unapprove_public(public spender: address, public amount: u128) -> Final;
-    fn transfer_from_public(public owner: address, public recipient: address, public amount: u128) -> Final;
-    fn transfer_from_public_to_private(
-        public owner: address,
-        recipient: address,
-        public amount: u128,
-    ) -> (ComplianceRecord, Token, Final);
 
+    //=============================================================
+    //               TRANSFER FUNCTIONS
+    //=============================================================
+    fn transfer_public(public recipient: address, public amount: u128) -> Final;
     fn transfer_private(
-        recipient: address,
-        amount: u128,
-        input_record: Token,
-        sender_merkle_proofs: [freezelist.aleo::MerkleProof; 2u32],
+        private recipient: address,
+        private amount: u128,
+        private input_record: Token,
+        private sender_merkle_proofs: [MerkleProof; 2u32],
     ) -> (ComplianceRecord, Token, Token, Final);
-
     fn transfer_private_to_public(
         public recipient: address,
         public amount: u128,
-        input_record: Token,
-        sender_merkle_proofs: [freezelist.aleo::MerkleProof; 2u32],
+        private input_record: Token,
+        private sender_merkle_proofs: [MerkleProof; 2u32],
     ) -> (ComplianceRecord, Token, Final);
-
     fn transfer_public_to_private(recipient: address, public amount: u128) -> (
         ComplianceRecord, Token, Final,
     );
+    fn transfer_from_public(public owner: address, public recipient: address, public amount: u128) -> Final;
+    fn transfer_from_public_to_private(
+        public owner: address,
+        private recipient: address,
+        public amount: u128,
+    ) -> (ComplianceRecord, Token, Final);
+    fn transfer_public_as_signer(public recipient: address, public amount: u128) -> Final;
 
+    //=============================================================
+    //               JOIN/SPLIT FUNCTIONS
+    //=============================================================
     fn join(input_1: Token, input_2: Token) -> Token;
     fn split(input: Token, amount: u128) -> (Token, Token);
 
+    //=============================================================
+    //                VIEW FUNCTIONS
+    //=============================================================
     view fn balance_of(account: address) -> u128;
     view fn allowance(owner: address, spender: address) -> u128;
     view fn supply() -> u128;
@@ -88,19 +102,18 @@ interface IARC22 {
 }
 ```
 
-**Public ↔ private conversions.** Use **`transfer_public_to_private`** (caller debits public balance; sender is `self.caller`, freeze check reads the public `freeze_list` mapping; returns **`(ComplianceRecord, Token, Final)`**) and **`transfer_private_to_public`** (private **`Token`** in; sender proves freeze-list non-inclusion with **`sender_merkle_proofs`**; credits recipient public balance; returns **`(ComplianceRecord, Token, Final)`**). Both emit a **`ComplianceRecord`** to **`INVESTIGATOR_ADDRESS`**.
-
-**Merkle non-inclusion proofs** are required only on transitions where the sender is private -- **`transfer_private`** and **`transfer_private_to_public`**. Transitions where the sender is public -- **`transfer_public_to_private`** and **`transfer_from_public_to_private`** -- read the **`freeze_list`** mapping directly for the sender, but still emit a **`ComplianceRecord`** because the recipient is private.
+**Merkle non-inclusion proofs** are required only on transitions where the sender is private -- **`transfer_private`** and **`transfer_private_to_public`**. Transitions where the sender is public -- **`transfer_public_to_private`** and **`transfer_from_public_to_private`** -- check the sender against the freeze list directly via **`is_frozen_address`** (or the equivalent **`verify_non_inclusion_pub`** helper).
 
 **Compliance coverage.** Every transition that moves balances on a private path -- **`transfer_private`**, **`transfer_private_to_public`**, **`transfer_public_to_private`**, and **`transfer_from_public_to_private`** -- emits a **`ComplianceRecord`** owned by **`INVESTIGATOR_ADDRESS`**, so the investigator can decrypt the full sender / recipient / amount tuple whenever at least one side is private.
 
-### Record Types
+#### Record Types
 
 **Token** -- Represents a private token balance. Implementations may add additional fields beyond `owner` and `amount`:
 ```leo
 record Token {
     owner: address,
     amount: u128,
+    ..
 }
 ```
 
@@ -112,14 +125,42 @@ record ComplianceRecord {
     amount: u128,
     sender: address,    // ZERO_ADDRESS for mint paths
     recipient: address, // ZERO_ADDRESS for burn paths
+    ..
 }
 ```
 
-The interface declares both records with `..`, so implementations may add fields. The reference template uses the exact two-field `Token` and four-field `ComplianceRecord` shown above.
+The interface declares both records with `..`, so implementations may add fields.
 
-### Freeze-List Mechanism
+### `IARC22Freezelist`
 
 The freeze list prevents sanctioned or compromised addresses from transacting. It uses a Merkle tree to enable privacy-preserving verification.
+
+```leo
+interface IARC22Freezelist {
+    fn initialize(public admin: address, public blocks: u32) -> Final;
+    fn update_freeze_list(
+        public account: address,
+        public is_frozen: bool,
+        public index: u32,
+        public existing_root: field,
+        public new_root: field,
+    ) -> Final;
+    fn verify_non_inclusion_pub(public account: address) -> Final;
+    fn verify_non_inclusion_priv(account: address, merkle_proof: [MerkleProof; 2u32]) -> Final;
+
+    //=============================================================
+    //                VIEW FUNCTIONS
+    //=============================================================
+    view fn is_frozen_address(account: address) -> bool;
+    view fn is_frozen_index(index: u32) -> bool;
+    view fn current_freeze_list_root() -> field;
+    view fn previous_freeze_list_root() -> field;
+    view fn root_updated_height() -> u32;
+    view fn block_height_window() -> u32;
+}
+```
+
+As with **`IARC22`**, mappings and storage variables are intentionally **not** part of the interface; implementations are free to choose their own backing storage. State is exposed exclusively through the view functions above.
 
 #### Merkle Non-Inclusion Proofs
 
@@ -129,111 +170,111 @@ Private transfers require the sender to prove they are **not** on the freeze lis
 2. To prove non-inclusion, the sender provides Merkle proofs for two adjacent leaves in the tree, showing that their address falls in the **gap** between them (or before the first / after the last frozen address)
 3. The proof verifies against the current (or previous) Merkle root stored on-chain
 
+The `MerkleProof` struct (defined in the `IARC22` library, see below) carries the sibling path and leaf index used for verification.
+
 #### Windowed Root Updates
 
-When the freeze list is updated, the Merkle root changes. A `BLOCK_HEIGHT_WINDOW` mechanism prevents race conditions:
+When the freeze list is updated, the Merkle root changes. A `block_height_window` mechanism prevents race conditions:
 
 - Both the current and previous Merkle roots are stored on-chain
-- Proofs generated against the previous root remain valid for `BLOCK_HEIGHT_WINDOW` blocks after a root update
+- Proofs generated against the previous root remain valid for `block_height_window` blocks after a root update
 - This allows in-flight transactions with proofs generated before a freeze list update to still succeed
 
-#### `freezelist.aleo` State
+#### `IARC22Freezelist` View Functions
 
-| Mapping | Key | Value | Description |
-|---------|-----|-------|-------------|
-| `freeze_list` | `address` | `bool` | Whether an address is frozen |
-| `freeze_list_index` | `u32` | `address` | Ordered index of frozen addresses |
-| `freeze_list_last_index` | `bool` | `u32` | Last used index in the freeze list |
-| `freeze_list_root` | `u8` (1 or 2) | `field` | Current and previous Merkle roots |
-| `root_updated_height` | `bool` | `u32` | Block height of last root update |
-| `block_height_window` | `bool` | `u32` | Number of blocks the previous root remains valid |
+| View Function | Returns | Description |
+|---------------|---------|-------------|
+| `is_frozen_address(account)` | `bool` | Whether `account` is currently on the freeze list |
+| `is_frozen_index(index)` | `bool` | Whether the slot at `index` is occupied by a frozen address |
+| `current_freeze_list_root()` | `field` | The current Merkle root of the freeze-list tree |
+| `previous_freeze_list_root()` | `field` | The previous Merkle root, still valid within the block-height window |
+| `root_updated_height()` | `u32` | Block height at which the root was last updated |
+| `block_height_window()` | `u32` | Number of blocks for which the previous root remains valid |
+
+### Library Constants
+
+The `IARC22` library exports the following constants. Implementations should use these values.
+
+| Constant | Type | Value | Purpose |
+|----------|------|-------|---------|
+| `MAX_TREE_DEPTH` | `u32` | `15u32` | Maximum depth of the freeze-list Merkle tree. Bounds the `siblings` array size at `MAX_TREE_DEPTH + 1`. |
+| `ZERO_ADDRESS` | `address` | `aleo1qqq...3ljyzc` (encoding of `0field`) | Sentinel used as `sender` for mint paths and `recipient` for burn paths in `ComplianceRecord`. |
+| `EMPTY_ROOT` | `field` | `H(ZERO_ADDRESS, ZERO_ADDRESS)` (Poseidon-based) | Initial Merkle root of an empty freeze list, used at `initialize` time. |
+
+### `MerkleProof`
+
+`MerkleProof` is defined in the `IARC22` library itself. Implementations reference it directly as `MerkleProof`.
+
+```leo
+struct MerkleProof {
+    siblings: [field; MAX_TREE_DEPTH + 1],
+    leaf_index: u32,
+}
+```
+
+### Merkle Helper Functions
+
+The library exposes helpers that implementations use to verify Merkle proofs. They use Poseidon4 hashes with a domain-separation tag (`0field` for internal nodes, `1field` for leaf pairs).
+
+| Function | Signature | Purpose |
+|----------|-----------|---------|
+| `calculate_hash_for_nodes` | `(sibling1: field, sibling2: field, indexbit: u32) -> field` | Hash two internal sibling nodes, ordered by `indexbit`. |
+| `calculate_hash_for_leaves` | `(sibling1: field, sibling2: field, indexbit: u32) -> field` | Hash the leaf-level sibling pair, ordered by `indexbit`. |
+| `calculate_root_depth_siblings` | `(merkle_proof: MerkleProof) -> (field, u32)` | Reconstruct the Merkle root from a proof; stops at the first `0field` sibling and returns `(root, depth)`. |
+| `verify_inclusion` | `(addr: address, merkle_proof: MerkleProof) -> field` | Assert `addr` matches the leaf and return the reconstructed root for comparison against a known root. |
+| `verify_non_inclusion` | `(addr: address, merkle_proofs: [MerkleProof; 2]) -> field` | Verify `addr` falls in the gap between two adjacent sorted leaves (or before the first / after the last) and return the common root. |
+
+`verify_non_inclusion` assumes the freeze-list tree is sorted in ascending order by address (cast to `field`). It is the function private senders rely on to prove they are not on the freeze list.
 
 ### Compliance Records
 
-Transitions that move balances along a private path emit a **`ComplianceRecord`** with **`owner`** set to **`INVESTIGATOR_ADDRESS`**, so only the investigator can decrypt the record and view the transfer details (sender, recipient, amount). The reference template emits **`ComplianceRecord`** on:
+Transitions that move balances along a private path emit a **`ComplianceRecord`** with **`owner`** set to a designated investigator address, so only that address can decrypt the record and view the transfer details (sender, recipient, amount). The reference template emits **`ComplianceRecord`** on the following transitions. The first four are part of the **`IARC22`** interface; **`mint_private`** and **`burn_private`** are admin extensions added by the reference template (see "ARC22 Tokens In Practice" below) and are **not** part of the interface.
 
-| Transition | `sender` field | `recipient` field |
-|------------|----------------|--------------------|
-| **`transfer_private`** | `input_record.owner` (private) | `recipient` (private) |
-| **`transfer_private_to_public`** | `input_record.owner` (private) | `recipient` (public input) |
-| **`transfer_public_to_private`** | `self.caller` (public) | `recipient` (private) |
-| **`transfer_from_public_to_private`** | `owner` (public) | `recipient` (private) |
-| **`mint_private`** (admin path) | `ZERO_ADDRESS` | `recipient` (private) |
-| **`burn_private`** (admin path) | `input_record.owner` | `ZERO_ADDRESS` |
+| Transition | Part of `IARC22`? | `sender` field | `recipient` field |
+|------------|-------------------|----------------|--------------------|
+| **`transfer_private`** | yes | `input_record.owner` (private) | `recipient` (private) |
+| **`transfer_private_to_public`** | yes | `input_record.owner` (private) | `recipient` (public input) |
+| **`transfer_public_to_private`** | yes | `self.caller` (public) | `recipient` (private) |
+| **`transfer_from_public_to_private`** | yes | `owner` (public) | `recipient` (private) |
+| **`mint_private`** (admin path) | no | `ZERO_ADDRESS` | `recipient` (private) |
+| **`burn_private`** (admin path) | no | `input_record.owner` | `ZERO_ADDRESS` |
 
 Fully public transitions (**`transfer_public`**, **`transfer_public_as_signer`**, **`transfer_from_public`**, **`mint_public`**, **`burn_public`**) do **not** emit a **`ComplianceRecord`** -- the sender, recipient, and amount are already public inputs visible on-chain.
 
-### Investigator Address
+### ARC22 Tokens In Practice
 
-The investigator address is hardcoded as the `INVESTIGATOR_ADDRESS` constant in `compliant_token_template.aleo`. It can only be changed by deploying a new edition of the program, which is gated by `multisig_core.aleo` signing operations. This ensures that changes to the investigator require multi-party approval.
+While not required by the interface, deployers will likely need a set of admin capabilities for a fully-functioning regulated token:
 
-### Admin & Operational Surface (non-interface)
-
-`compliant_token_template.aleo` also exposes admin transitions that are **not** part of **`IARC22`** but are required for a functioning regulated token:
+- **Role-gated Access Controls** -- various predefined roles that only allow an approved subset of users to call certain functions.  Roles may include `MINTER_ROLE`, `BURNER_ROLE`, `PAUSE_ROLE`, `MANAGER_ROLE`, and `FREEZELIST_MANAGER_ROLE`.
 
 - **`initialize(name, symbol, decimals, max_supply, admin)`** -- one-time setup, callable only by `DEPLOYER_ADDRESS`; populates `storage token_info`, sets `pause = false`, marks `initialized = true`, and assigns `MANAGER_ROLE` to `admin`.
+
 - **`update_role(new_address, role)`** -- manager-only role bitmask updates; supports `MINTER_ROLE`, `BURNER_ROLE`, `PAUSE_ROLE`, `MANAGER_ROLE`.
+
 - **`mint_public(recipient, amount)` / `mint_private(recipient, amount)`** -- gated by `MINTER_ROLE`; both honor `pause` and `max_supply`. `mint_private` emits a **`ComplianceRecord`** with `sender = ZERO_ADDRESS`.
+
 - **`burn_public(owner, amount)` / `burn_private(input_record, amount)`** -- gated by `BURNER_ROLE`. `burn_private` emits a **`ComplianceRecord`** with `recipient = ZERO_ADDRESS`.
+
 - **`set_pause_status(pause_status)`** -- gated by `PAUSE_ROLE`; toggles the `pause` storage flag, which blocks every balance-moving transition.
-- **`get_signing_op_id_for_deploy(checksum, edition)`** -- helper for computing the multisig signing op id needed to upgrade the program.
 
-### Dynamic Dispatch
-
-**`IARC22`** is a Leo `interface`, so transitions can be called dynamically using interface-enforced syntax (`Interface@(target)::function(args)`):
-
+- **`Credentials` Record / `transfer_private_with_creds`** -- Allows users to only need to generate the Merkle non-inclusion proof one time, then continue to execute private transfers without needing to reprove (assuming the freeze list root hasn't changed)
 ```leo
-IARC22@(token_program)::transfer_public(recipient, amount);
-IARC22@(token_program)::approve_public(spender, amount);
-IARC22@(token_program)::transfer_from_public(owner, recipient, amount);
+record Credentials {
+    owner: address,
+    freeze_list_root: field,
+}
 ```
+-  **`INVESTIGATOR_ADDRESS`** -- The investigator address should be hardcoded as the `INVESTIGATOR_ADDRESS` constant in `compliant_token_template.aleo`. In practice, this only allows it to be changed by deploying a new edition of the program, which should be gated by multi-sig signing operations. This ensures that changes to the investigator require multi-party approval.
 
-See [ARC-20 Dynamic Dispatch](../arc-0020/#dynamic-dispatch) for the full syntax reference, the `_dynamic_call` intrinsic, and worked examples.
 
-Private transitions (**`transfer_private`**, **`transfer_private_to_public`**, **`transfer_from_public_to_private`**, **`transfer_public_to_private`**, etc.) can also be invoked dynamically -- the caller supplies Merkle non-inclusion proofs where required. **`ComplianceRecord`** outputs return as dynamic records where applicable (see Leo's dynamic records documentation).
 
-## Test Cases
-
-Tests use Jest with a local devnode and Leo CLI execution.
-
-**Compliant token template tests** (`compliant-token-template.test.js`):
-- `initialize`: Rejects duplicate initialization; only `DEPLOYER_ADDRESS` may call
-- `update_role`: Manager assigns roles; manager cannot demote themselves without `MANAGER_ROLE`
-- `mint_public` / `mint_private`: Gated by `MINTER_ROLE`, honor `pause` and `max_supply`; `mint_private` emits a `ComplianceRecord`
-- `burn_public` / `burn_private`: Gated by `BURNER_ROLE`; `burn_private` emits a `ComplianceRecord`
-- `transfer_public` / `transfer_public_as_signer`: Move balances; reject insufficient balance and frozen sender/recipient
-- `approve_public` / `unapprove_public`: Manage allowances (keyed by the `TokenAllowance` struct directly)
-- `transfer_from_public`: Spender transfers with allowance
-- `transfer_public_to_private` / `transfer_from_public_to_private`: Public-to-private conversions; both emit a `ComplianceRecord`
-- `transfer_private_to_public`: Private-to-public conversion with freeze-list non-inclusion proofs; emits a `ComplianceRecord` and returns `(ComplianceRecord, Token, Final)`
-- `transfer_private`: Private transfer with freeze-list proofs and `ComplianceRecord`
-- `pause/unpause`: `set_pause_status` (gated by `PAUSE_ROLE`) blocks and unblocks transfers
-- **`view fn`** reads: `balance_of`, `allowance`, `supply`, `max_supply`, `decimals`, `name`, `symbol`
-
-## Reference Implementations
-
-- [`compliant_token_template/`](./compliant_token_template/) -- **`IARC22`** implementation with freeze list integration, Merkle non-inclusion verification, **`view fn`** metadata/supply reads (`balance_of`, `allowance`, `supply`, `max_supply`, `decimals`, `name`, `symbol`), shared **`add_supply` / `sub_supply`** bookkeeping, role-based admin (`MINTER_ROLE`, `BURNER_ROLE`, `PAUSE_ROLE`, `MANAGER_ROLE`), and multisig-gated upgrades via `multisig_core.aleo`
-- [`freezelist/`](./freezelist/) -- On-chain freeze list using a Merkle tree with windowed root updates for proof validity across blocks
-
-## Dependencies
-
-- [ARC-20](../arc-0020/) -- **`IARC22`** tokens mirror ARC-20-style transfer primitives with extra compliance constraints (freeze-list proofs on sensitive paths, **`ComplianceRecord`** emission where specified)
-- **Leo compiler** with interface/dynamic dispatch support
-- **merkle_tree.aleo** and **multisig_core.aleo** -- Deployed as on-chain dependencies; `merkle_tree.aleo` provides Merkle tree verification primitives, `multisig_core.aleo` gates program upgrades
-- **@provablehq/sdk** (for SDK-based testing)
-- **@sealance-io/policy-engine-aleo** (Merkle proof generation for tests)
-
-## Backwards Compatibility
-
-ARC-22 is a new standard and has no backwards compatibility concerns. Programs implementing **`IARC22`** are not required to declare Leo conformance to the **`IARC20`** interface from ARC-20, because compliance paths change signatures (freeze-list proofs, **`ComplianceRecord`** outputs, public `recipient` / `amount` inputs on `transfer_private_to_public`).
-
-## Security Considerations
+<!-- ## Security Considerations
 
 **Freeze list**: The **`IARC22`** surface enforces freeze-list checks on every balance-moving path:
 
-- Fully public sender paths (`transfer_public`, `transfer_public_as_signer`, `transfer_from_public`) read the **`freeze_list`** mapping directly for both sender and recipient.
-- Public-sender / private-recipient paths (`transfer_public_to_private`, `transfer_from_public_to_private`) read **`freeze_list`** directly for the sender; recipient is not checked at the freeze-list level because the recipient address may itself be private to the call site.
-- Private-sender paths (`transfer_private`, `transfer_private_to_public`) verify Merkle non-inclusion proofs against the current or previous freeze-list Merkle root, plus a direct **`freeze_list`** check on the public recipient in `transfer_private_to_public`.
+- Fully public sender paths (`transfer_public`, `transfer_public_as_signer`, `transfer_from_public`) check the freeze list directly via **`is_frozen_address`** (or **`verify_non_inclusion_pub`**) for both sender and recipient.
+- Public-sender / private-recipient paths (`transfer_public_to_private`, `transfer_from_public_to_private`) check the sender via **`is_frozen_address`**; the recipient is not checked at the freeze-list level because the recipient address may itself be private to the call site.
+- Private-sender paths (`transfer_private`, `transfer_private_to_public`) verify Merkle non-inclusion proofs against the current or previous freeze-list Merkle root, plus a direct **`is_frozen_address`** check on the public recipient in `transfer_private_to_public`.
 
 A windowed root update mechanism allows proofs generated against a previous root to remain valid for `BLOCK_HEIGHT_WINDOW` blocks after a root update, preventing race conditions where a freeze-list update invalidates in-flight transactions.
 
@@ -241,22 +282,7 @@ A windowed root update mechanism allows proofs generated against a previous root
 
 **Pause kill-switch**: Every balance-moving transition checks `storage pause` and aborts when paused. Only addresses holding `PAUSE_ROLE` can toggle the flag via `set_pause_status`.
 
-**Upgradability**: `compliant_token_template.aleo` and `freezelist.aleo` gate program upgrades behind `multisig_core.aleo` signing operations (see the `@custom` constructor and `get_signing_op_id_for_deploy` helper), ensuring that code changes require multi-party approval.
-
-## Testing
-
-Prerequisites:
-- Leo compiler with interface support (build from source)
-- Node.js 18+
-
-```bash
-cd arc-0022/tests
-npm install
-npm test                    # Run all tests (requires local devnode)
-npm run test:compliant-token-template  # Run compliant token tests only
-```
-
-Tests start a local devnode, deploy programs with their dependencies, and execute transactions via `leo execute`.
+**Upgradability**: `compliant_token_template.aleo` gates program upgrades behind `multisig_core.aleo` signing operations (see the `@custom` constructor and `get_signing_op_id_for_deploy` helper), ensuring that code changes require multi-party approval. -->
 
 ## Copyright
 

--- a/arc-0022/freezelist/.gitignore
+++ b/arc-0022/freezelist/.gitignore
@@ -1,0 +1,5 @@
+.env
+*.avm
+*.prover
+*.verifier
+outputs/

--- a/arc-0022/freezelist/tests/test_arc22freezelist.leo
+++ b/arc-0022/freezelist/tests/test_arc22freezelist.leo
@@ -1,0 +1,14 @@
+// The 'test_arc22freezelist' test program.
+import arc22freezelist.aleo;
+
+program test_arc22freezelist.aleo {
+    @test
+    @should_fail
+    fn test_main_fails() {
+        let result: u32 = arc22freezelist.aleo::main(2u32, 3u32);
+        assert_eq(result, 3u32);
+    }
+
+    @noupgrade
+    constructor() {}
+}


### PR DESCRIPTION
## Summary

Introduces the **`IARC20`** and **`IARC22`** interface libraries (program.json + lib.leo) and rewrites both ARC READMEs to document them.

This PR is the substantive half of the changes that were previously bundled into #128. It isolates the new spec content so reviewers can focus on the interfaces and prose without wading through the file-deletion noise. The remaining cleanup (removing the old build artifacts, test infrastructure, and reference programs that the new spec supersedes) stays in #128 and will be rebased on top of this once merged.

### What's in this PR
- `arc-0020/IARC20/` — new IARC20 interface library
- `arc-0022/IARC22/` — new IARC22 interface library (compliant token + freezelist)
- `arc-0020/README.md` — rewritten to match the IARC20 interface
- `arc-0022/README.md` — rewritten to document the IARC22 and IARC22Freezelist interfaces, MerkleProof struct, library constants, and Merkle helpers

### Suggested review order
1. `arc-0020/IARC20/src/lib.leo` and `arc-0020/README.md`
2. `arc-0022/IARC22/src/lib.leo` and `arc-0022/README.md`

## Test plan
- [ ] `IARC20/src/lib.leo` compiles under the declared Leo version
- [ ] `IARC22/src/lib.leo` compiles under the declared Leo version
- [ ] READMEs accurately reflect the interfaces declared in each `lib.leo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)